### PR TITLE
feature(github): [UNITY-1234] Add PR labeler configuration

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -1,0 +1,42 @@
+ci/cd:
+  - .github/**
+
+documentation:
+  - README.md
+  - docs/**
+  - ./*.md
+
+core:
+  - Assets/Convai/Plugins**
+  - Runtime/**
+
+speech:
+  - Assets/Convai/Scripts/Runtime/**
+
+character:
+  - Assets/Convai/Scripts/Character/**
+
+actions:
+  - Assets/Convai/Scripts/Actions/**
+
+lipsync:
+  - Assets/Convai/Scripts/Lipsync/**
+
+examples:
+  - Assets/Convai/Examples/**
+
+tests:
+  - Assets/Tests/**
+
+editor:
+  - Editor/**
+
+plugins:
+  - Plugins/**
+
+third-party:
+  - ThirdParty/**
+
+build:
+  - ProjectSettings/**
+  - Packages/**

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,73 @@
+name: Unity SDK Pull Request Labeling
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: size-label
+        uses: "pascalgn/size-label-action@v0.5.4"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          sizes: >
+            {
+              "10": "XS",
+              "100": "S",
+              "250": "M",
+              "500": "L",
+              "1000": "XL",
+              "2000": "XXL"
+            }
+
+  unity-specific-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Label Unity-specific changes
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            function hasUnityChanges(files, directory) {
+              return files.some(file => file.startsWith(directory));
+            }
+
+            const { data: changedFiles } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const filePaths = changedFiles.map(file => file.filename);
+
+            const labelsToAdd = [];
+
+            if (hasUnityChanges(filePaths, 'Assets/')) labelsToAdd.push('unity-assets');
+            if (hasUnityChanges(filePaths, 'ProjectSettings/')) labelsToAdd.push('unity-settings');
+            if (hasUnityChanges(filePaths, 'Packages/')) labelsToAdd.push('unity-packages');
+            if (hasUnityChanges(filePaths, 'Assets/Convai/Editor/')) labelsToAdd.push('unity-editor');
+            if (hasUnityChanges(filePaths, 'Assets/Convai/Plugins/')) labelsToAdd.push('unity-plugins');
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labelsToAdd
+              });
+            }


### PR DESCRIPTION
## Pull Request Description

### What
Added a new GitHub Actions workflow for automated labeling of Unity SDK pull requests.

### Why
To improve the organization and categorization of pull requests in our Unity SDK repository, making it easier for maintainers to identify the scope and impact of changes.

### How
Implemented a new GitHub Actions workflow (`pr-labeler.yml`) that:
1. Uses the `actions/labeler` action for general labeling based on file paths.
2. Applies size labels to PRs based on the number of changes.
3. Adds Unity-specific labels based on changes in specific directories.

### Related Issues
- Jira Ticket: [UNITY-1507](https://convaixr.atlassian.net/browse/UNITY-1507)

## Code Checklist
- [x] Code follows project style guidelines
- [ ] Unit tests have been added or updated
- [x] Documentation has been updated (workflow file is self-documenting)
- [ ] Code has been reviewed by at least one other developer
- [ ] All CI/CD checks are passing

## Additional Information
- [ ] This PR introduces breaking changes
- [ ] This PR requires database migrations
- [ ] This PR affects performance

## Screenshots (if applicable)
N/A

## Other Notes
This PR introduces a new GitHub Actions workflow for automated labeling. It includes:
1. General labeling based on file paths (using `labeler.yml` configuration)
2. Size labeling for PRs (XS, S, M, L, XL, XXL)
3. Unity-specific labeling for changes in Assets, ProjectSettings, Packages, Editor, and Plugins directories

The `labeler.yml` file has also been updated to include more specific labeling rules for various parts of the Unity SDK project.